### PR TITLE
Use single-layer directory structure for disk-tier

### DIFF
--- a/include/txn/base_store.hpp
+++ b/include/txn/base_store.hpp
@@ -263,8 +263,7 @@ public:
    */
   bool read_disk(const K &k) {
     // Key not being used right now, check if stored in disk
-    string fname = ebs_root + std::to_string(thread_id) + "/" + k;
-    // TODO: create dir if DNE
+    string fname = ebs_root + std::to_string(thread_id) + "-" + k;
     std::fstream f(fname, std::ios::in | std::ios::binary);
     if (f) {
       // Key exists on disk, read it into the map
@@ -300,7 +299,7 @@ public:
       // Write it back to disk
 
       // TODO: create dir if DNE
-      string fname = ebs_root + std::to_string(thread_id) + "/" + k;
+      string fname = ebs_root + std::to_string(thread_id) + "-" + k;
       std::fstream f(fname, std::ios::out | std::ios::binary);
       f << db.at(k).get_is_primary() << "\n" << db.at(k).reveal() << "\n";
       f.close();
@@ -431,7 +430,7 @@ public:
 
   void remove(const K &k) {
     db.erase(k);
-    std::remove((ebs_root + "/" + std::to_string(thread_id) + "/" + k).c_str());
+    std::remove((ebs_root + std::to_string(thread_id) + "-" + k).c_str());
   }
 };
 


### PR DESCRIPTION
C++11 doesn't have a standardized way to do directory manipulation without using Boost or OS-specific libraries. The simple solution is to not use sub-directories, and just name the files `<thread_id>-<key>` within the `ebs_root`, which we assume exists.